### PR TITLE
Return resized image issue fixed

### DIFF
--- a/src/img_resizing_lambda.rs
+++ b/src/img_resizing_lambda.rs
@@ -56,16 +56,25 @@ async fn download_img_from_s3(
     let bytes_mutref = s3_object_bytes_mut.as_ref();
 
     let resized_image = resize_image(bytes_mutref);
-    let resized_image_slice = &[..resized_image];
 }
+    
 
-fn resize_image(bytes_img: &[u8]) -> Vec<u8> {
+ fn resize_image(bytes_img: &[u8]) -> Vec<u8> {
+
+    let mut img_result: Vec<u8> = Vec::new();
+
     let image = match image::load_from_memory(bytes_img) {
         Ok(image) => image,
         Err(imgerr) => panic!("Couldn't convert S3 Object to Image Bytes! {}", imgerr),
     };
-    let scaled = image.resize_exact(299, 299, FilterType::CatmullRom).to_bytes();
+    let scaled = image.resize_exact(299, 299, FilterType::CatmullRom);
 
-    return scaled //returning as a vector because cannot return as a reference to local variable
-    
+    match scaled.write_to(&mut img_result, image::ImageOutputFormat::Jpeg(90)){   //setting the jpeg quality to 90
+        Ok(scaledimg) => scaledimg,
+        Err(write_err) => panic!("Couldn't convert S3 Object to Image Bytes! {}", write_err),
+    }
+    return img_result 
 }
+
+
+


### PR DESCRIPTION
Writing to a vector instead of converting using `to_bytes()` as it does not preserve the image format.