### PR TITLE
removed snake case warnings

### DIFF
--- a/src/Image_Lib.rs
+++ b/src/Image_Lib.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use image::imageops::FilterType;
 use std::env;
 use std::path::Path;

--- a/src/Raster_Lib.rs
+++ b/src/Raster_Lib.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use raster::editor;
 use std::env;
 

--- a/src/img_resizing_lambda.rs
+++ b/src/img_resizing_lambda.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use futures::TryStreamExt;
 use image::imageops::FilterType;
 use rusoto_core::{ByteStream, Region};

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 use image::{imageops::FilterType, GenericImageView, ImageBuffer};
 mod img_resizing_lambda;
 


### PR DESCRIPTION
Removed snake case warnings from the files in src folder - `Image_Lib.rs` `img_resizing_lambda.rs` `Raster_Lib.rs` 'test.rs`